### PR TITLE
Make gatsby-remark-source-name compatible with gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-source-name",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Add a custom sourceName field to remark nodes",
   "main": "index.js",
   "repository": "https://www.github.com/elboman/gatsby-remark-source-name",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,5 @@
-exports.onCreateNode = ({ node, getNode, boundActionCreators }) => {
-  const { createNodeField } = boundActionCreators;
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  const { createNodeField } = actions;
 
   // We only care about MarkdownRemark content.
   if (node.internal.type !== 'MarkdownRemark') {


### PR DESCRIPTION
Gatsby v3 has some breaking changes, this makes it work again.

I also bumped the version number as this would probably be a breaking change for gatsby-remark-source-name itself.